### PR TITLE
feat: seed §356a revocation feature defaults

### DIFF
--- a/src/demodata.sql
+++ b/src/demodata.sql
@@ -406,6 +406,17 @@ INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`, `OXVARNAME`, `OXVARTYPE`
 ('omc4555952125c3c2.98253113',1,'','blDisableNavBars','bool','1'),
 ('rgk2a8c9cf8c9d23b3a7c8e9c090baf1',1,'','sTheme','str','wave');
 
+-- §356a BGB electronic revocation feature (issue #99). Default-on for fresh
+-- installs; OXIDs match source/Setup/Sql/initial_data.sql so INSERT IGNORE
+-- here is a no-op on the no-demo install branch where initial_data.sql
+-- already seeds these rows. See design.md D5 for the absent-row code-default
+-- semantics on upgrades.
+INSERT IGNORE INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`, `OXVARNAME`, `OXVARTYPE`, `OXVARVALUE`) VALUES
+    ('c7c6ef985f845e56417339ae7b930b20', 1, '', 'blShowRevocationForm',       'bool', '1'),
+    ('b4f36c830c18f275eef33491246b822e', 1, '', 'blRevocationRequireLogin',   'bool', '0'),
+    ('f4a110db564dcf6528ede68bddebe75c', 1, '', 'blRevocationNotifyOperator', 'bool', '1'),
+    ('222ef6f2a5c46a0f105c3ce2ca538f0b', 1, '', 'sRevocationOperatorEmail',   'str',  '');
+
 INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`, `OXVARNAME`, `OXVARTYPE`, `OXVARVALUE`) VALUES
 ('0c6c988ca3077f8dc8028b22bf1cd5f4', 1, 'theme:wave', 'aNrofCatArticlesInGrid', 'arr', 'a:4:{i:0;s:2:"12";i:1;s:2:"16";i:2;s:2:"24";i:3;s:2:"32";}'),
 ('0f7a2bae161e97f836d606396ba13277', 1, 'theme:wave', 'blFooterShowLinks', 'bool', '1'),


### PR DESCRIPTION
## Summary

Seeds the four §356a BGB electronic revocation config rows into the fresh-install demodata so a clean shop boots with the feature visibly active:

| Variable | Type | Default | Purpose |
|---|---|---|---|
| `blShowRevocationForm` | bool | `1` | Master switch — renders the footer entry-link and the `cl=revocation` controller. |
| `blRevocationRequireLogin` | bool | `0` | When `1`, link is hidden for anonymous visitors. |
| `blRevocationNotifyOperator` | bool | `1` | Send the operator confirmation email on submission. |
| `sRevocationOperatorEmail` | str | `''` | Recipient — empty in demodata, falls back to shop owner email. |

## Why

Without these rows the visibility matrix in `ViewConfig::getRevocationLinkVisible()` resolves to `false` on a fresh install — making the new feature invisible until an admin manually toggles it. Seeding the defaults aligns demodata with the shipped feature behaviour.

## Companion PRs

- shop-ce: issue #99 (this branch is `99-add-electronic-revocation-function-b2`)
- o3-Theme: o3-shop/o3-Theme#16
- wave-theme: o3-shop/wave-theme#2

## Test plan

- [ ] Fresh install with this demodata → footer SERVICE column shows "Vertrag widerrufen" / "Cancel contract".
- [ ] `cl=revocation` controller renders the form.
- [ ] Submitting the form sends the operator + customer confirmation emails.
- [ ] Admin → Shop settings → Revocation tab shows the four values matching the seeds above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)