### PR TITLE
Make o3-theme the default theme (#118 companion)

### DIFF
--- a/src/demodata.sql
+++ b/src/demodata.sql
@@ -404,7 +404,7 @@ INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`, `OXVARNAME`, `OXVARTYPE`
 ('mhjf24905a5b49c8d60aa31087b97971',1,'','blEnableSeoCache','bool','1'),
 ('mhjf24905a5b49c8d60aa31087b9797f',1,'','blShowRememberMe','bool','1'),
 ('omc4555952125c3c2.98253113',1,'','blDisableNavBars','bool','1'),
-('rgk2a8c9cf8c9d23b3a7c8e9c090baf1',1,'','sTheme','str','wave');
+('rgk2a8c9cf8c9d23b3a7c8e9c090baf1',1,'','sTheme','str','o3-theme');
 
 -- §356a BGB electronic revocation feature (issue #99). Default-on for fresh
 -- installs; OXIDs match source/Setup/Sql/initial_data.sql so INSERT IGNORE


### PR DESCRIPTION
## Summary

- Set `sTheme = 'o3-theme'` so a fresh install with demodata loads the new default theme.

Mirrors the change in `source/Setup/Sql/initial_data.sql` of the shop core.

## Companion PR

Must merge with [o3-shop/shop-ce#112](https://github.com/o3-shop/shop-ce/pull/112), which:
- flips initial_data.sql in shop-ce
- syncs the drifted theme:o3-theme color / logo / thumbnail values
- backfills missing settings
- patches `bin/o3-setup` to apply initial_data.sql to dev installs

References [o3-shop/o3-shop#118](https://github.com/o3-shop/o3-shop/issues/118).

## Test plan

- [x] Verified together with shop-ce#112 by dropping the dev DB volume and reinstalling — `sTheme=o3-theme` after install, storefront renders with the new default
- [x] Full unit test suite green in shop-ce (8462 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)