### PR TITLE
Refresh currency exchange rates to ECB 2026-04-30 (sync with shop-ce #128)

### DIFF
--- a/src/demodata.sql
+++ b/src/demodata.sql
@@ -235,7 +235,7 @@ INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`, `OXVARNAME`, `OXVARTYPE`
 ('33c8ca2399ec4c9baf1c2669529220e9',1,'theme:flow','sBlogUrl','str','https://wordpress.org'),
 ('36d42513de8cab671.54909813',1,'','bl_perfShowActionCatArticleCnt','bool','1'),
 ('37fbd352a75a6db2af525b13378c69cf',1,'theme:flow','sGoogleMapsAddr','str','O3-Shop, Musterstr. 17, 12345 Musterstadt'),
-('3c4f033dfb8fd4fe692715dda19ecd28',1,'','aCurrencies','arr','a:4:{i:0;s:23:"EUR@ 1.00@ ,@ .@ €@ 2";i:1;s:24:"GBP@ 0.8565@ .@  @ £@ 2";i:2;s:40:"CHF@ 1.4326@ ,@ .@ <small>CHF</small>@ 2";i:3;s:23:"USD@ 1.2994@ .@  @ $@ 2";}'),
+('3c4f033dfb8fd4fe692715dda19ecd28',1,'','aCurrencies','arr','a:4:{i:0;s:23:"EUR@ 1.00@ ,@ .@ €@ 2";i:1;s:24:"GBP@ 0.8663@ .@  @ £@ 2";i:2;s:40:"CHF@ 0.9190@ ,@ .@ <small>CHF</small>@ 2";i:3;s:23:"USD@ 1.1702@ .@  @ $@ 2";}'),
 ('43040112c71dfb0f2.40367454',1,'','sDefaultImageQuality','str','75'),
 ('43141b9b252874600.34636487',1,'','sDecimalSeparator','str',','),
 ('4369200546872115876e5bdd54d0f4ca',1,'','aLanguageSSLURLs','arr','a:2:{i:0;s:0:"";i:1;s:0:"";}'),


### PR DESCRIPTION
## Summary

Mirrors the seed update in [`shop-ce` PR #116](https://github.com/o3-shop/shop-ce/pull/116) for [issue o3-shop/o3-shop#128](https://github.com/o3-shop/o3-shop/issues/128). Same `aCurrencies` row, same OXID (`3c4f033dfb8fd4fe692715dda19ecd28`), same value — the demo install seed must match the fresh-install seed so currency UI shows the same numbers regardless of which install path was used.

| | Old | New |
|---|---|---|
| GBP | 0.8565 | **0.8663** |
| CHF | 1.4326 | **0.9190** |
| USD | 1.2994 | **1.1702** |

Source: ECB euro reference rates 2026-04-30 — <https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html>

All four are 6-character `X.XXXX` strings, same width as the legacy values, so the serialized-array length prefixes are untouched. Value-only diff.

## Test plan

- [ ] Fresh install with demodata loaded shows the new rates in admin → Master Settings → Core Settings → Settings → "Currencies"
- [ ] Either PR can land first without breaking the other (no cross-repo dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)